### PR TITLE
Adjusted the Assembly Handler reflection to use Declared Types rather…

### DIFF
--- a/src/Paramore.Brighter.AspNetCore/AspNetHandlerBuilder.cs
+++ b/src/Paramore.Brighter.AspNetCore/AspNetHandlerBuilder.cs
@@ -53,15 +53,14 @@ namespace Paramore.Brighter.AspNetCore
         private void RegisterHandlersFromAssembly(Type interfaceType, IEnumerable<Assembly> assemblies)
         {
             var subscribers =
-                from t in assemblies.SelectMany(a => a.ExportedTypes)
-                let ti = t.GetTypeInfo()
+                from ti in assemblies.SelectMany(a => a.DefinedTypes)
                 where ti.IsClass && !ti.IsAbstract && !ti.IsInterface
-                from i in t.GetTypeInfo().ImplementedInterfaces
+                from i in ti.ImplementedInterfaces
                 where i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == interfaceType
                 select new
                 {
                     RequestType = i.GenericTypeArguments.First(),
-                    HandlerType = t
+                    HandlerType = ti.AsType()
                 };
 
             foreach (var subscriber in subscribers)


### PR DESCRIPTION
… than only public types. For #2. Handlers can now be `internal` too. I didn't need to use `GetTypes()` in the end as `DefinedTypes` did the same job _and_ returned the `TypeInfo` we needed.

I attempted to create an xUnit test libraries to go with this commit but I found that the value of the test was minimal compared to the enormous boilerplate required to test reflection in external assemblies!